### PR TITLE
Updates for Coveralls badge

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: s4N1MXo48ujETQzbihJIj9jGxtVzXw7RU

--- a/Rakefile
+++ b/Rakefile
@@ -17,9 +17,8 @@ Bundler::GemHelper.install_tasks
 desc "Run all of the tests"
 Rake::TestTask.new do |config|
   config.libs << 'test'
-  config.pattern = 'test/**/*_test*'
+  config.pattern = 'test/**/*_test.rb'
   config.verbose = true
-  config.warning = true
 end
 
 desc "Generate all of the docs"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,7 @@
 require 'coveralls'
-Coveralls.wear!
+Coveralls.wear! do
+  add_filter "/test/"
+end
+require 'minitest/autorun'
 require 'timecop'
 require 'time-lord'

--- a/test/lib/time-lord/extentions/integer_test.rb
+++ b/test/lib/time-lord/extentions/integer_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+
 require 'helper'
 
 class TestTimeLordExtentionsInteger < MiniTest::Unit::TestCase

--- a/test/lib/time-lord/extentions/time_test.rb
+++ b/test/lib/time-lord/extentions/time_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+
 require_relative '../../../helper'
 
 class TestTimeLordExtentionsTime < MiniTest::Unit::TestCase

--- a/test/lib/time-lord/period_test.rb
+++ b/test/lib/time-lord/period_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+
 require 'helper'
 
 class TestTimeLordPeriod < MiniTest::Unit::TestCase
@@ -49,7 +49,7 @@ class TestTimeLordPeriod < MiniTest::Unit::TestCase
   def test_in_words_between_11_months_and_year
     expected = "11 months from now"
     Timecop.freeze(Time.local(2013, 1, 1))
-    actual = Time.local(2013, 12, 3).ago.in_words
+    actual = Time.local(2013, 12, 1).ago.in_words
     assert_equal(expected, actual)
   end
 

--- a/test/lib/time-lord/scale_test.rb
+++ b/test/lib/time-lord/scale_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+
 require 'helper'
 
 class TestTimeLordScale < MiniTest::Unit::TestCase

--- a/test/lib/time-lord/time_test.rb
+++ b/test/lib/time-lord/time_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+
 require 'helper'
 
 class TestTimeLordTime < MiniTest::Unit::TestCase

--- a/test/lib/time-lord_test.rb
+++ b/test/lib/time-lord_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+
 require 'helper'
 
 class TestTimeLord < MiniTest::Unit::TestCase


### PR DESCRIPTION
- moved "require 'minitest/autorun'" to test helper
- removed .coveralls.yml (repo token shouldn't be public; not needed
  for travis-ci)
- fixed failing test: test_in_words_between_11_months_and_year
